### PR TITLE
Hotfixed chromium scrolling issue

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -422,12 +422,14 @@ nav.navbar .navbar-toggler[aria-expanded="true"] .navbar-toggler-icon {
 .proj-imgbx {
   position: relative;
   border-radius: 30px;
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
   margin-bottom: 24px;
 }
 .proj-colbx
 {
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
   max-height: 250px;
   margin-bottom: 24px;
 }


### PR DESCRIPTION
Hotfixed an issue where chromium based browsers would not infer scrolling properties and would instead assume scrollbars where always present